### PR TITLE
Implemented idHUDElement cache in idHudManager

### DIFF
--- a/DE/idHudManager.cpp
+++ b/DE/idHudManager.cpp
@@ -60,10 +60,18 @@ bool idHudManager::acquireIsWorldMenuAtIndexActiveFuncAddr(__int64 faddr)
 
 
 idHUDElement* idHudManager::getIdHud_Element(std::string requestedHudElementName) {
-
+    static idPlayer* lastIdPlayerObj = idMapInstanceLocalManager::getIdPlayer();
     idPlayer* idPlayerObj = idMapInstanceLocalManager::getIdPlayer();
+
+    if (lastIdPlayerObj != idPlayerObj) {
+        m_elementCache.clear();
+        lastIdPlayerObj = idPlayerObj;
+    }
+    else if (m_elementCache.contains(requestedHudElementName)) {
+        return m_elementCache.at(requestedHudElementName);
+    }
+
     idList* IdHud_Elements_ListPtr = (idList*)&idPlayerObj->playerHud.idGrowableList_idHUDElement_elements;
-    //idList* IdHud_Elements_ListPtr = (idList*)&idPlayerObj->playerHud.idGrowableList_elements;
 
     if (!IdHud_Elements_ListPtr || MemHelper::isBadReadPtr(IdHud_Elements_ListPtr)) {
         logErr("getIdHud_Element: IdHud_Elements_ListPtr is null or badPtr");
@@ -79,11 +87,10 @@ idHUDElement* idHudManager::getIdHud_Element(std::string requestedHudElementName
 
         idDeclHUDElement* declElement = IdHud_Element->decl;
 
-
         std::string idHud_ElementNameStr = idResourceManager::getDeclHudElementName(declElement);
 
-
         if (idHud_ElementNameStr == requestedHudElementName) {
+            m_elementCache[requestedHudElementName] = IdHud_Element;
 
             return IdHud_Element;
         }

--- a/DE/idHudManager.h
+++ b/DE/idHudManager.h
@@ -28,6 +28,8 @@ private:
 
    static inline isWorldMenuAtIndexActive_t m_isWorldMenuAtIndexActiveFp = nullptr;
 
+   static inline std::unordered_map<std::string, idHUDElement*> m_elementCache;
+
 public:
 
 


### PR DESCRIPTION
fixes #1

I implemented a cache for the `idHUDElement` pointers in the` idHudManager` to improve performance.
In my testing I found that the calls to `idHudManager::getIdHud_Element` in `KaibzHudManager::getData` are very expensive due to their repeated calls to `VirtualQuery` via  `MemHelper::isBadReadPtr`.

I don't know a lot about the engine and the SDK and I am not too familiar with the mod, so doing this might not be OK in some scenarios.

My tests did not show anything suspicious though but more people need to confirm this.

I tested on a Ryzen 5 3600 and a Radeon 7900 XT and the average time of the Vulkan hook went from around 1.5ms to 0.28ms and the CPU frame time from around 5ms to around 3.7ms which is a significant improvement in CPU bound scenarios.