### PR TITLE
Implemented crash dump generation

### DIFF
--- a/DE/CommonDE.h
+++ b/DE/CommonDE.h
@@ -1124,7 +1124,8 @@ namespace Reticle {
 namespace modSettingsDefault {
 
 
-	static const bool defaultIsFirstTimeModLaunch = true;	
+	static const bool defaultGenerateCrashDump = false;
+	static const bool defaultIsFirstTimeModLaunch = true;
 
 	static const unsigned int defaultToggleModSettingsVkCode = VK_F8;
 	static const int  defaultmodSettingsShortcutTextColorImU32 = IM_COL32(255, 255, 255, 255); //white

--- a/DE/modSettings.cpp
+++ b/DE/modSettings.cpp
@@ -31,8 +31,9 @@ void modSettings::loadSettings()
 
     try {       
         nlohmann::json j;
-        file >> j;  
-       
+        file >> j;
+
+        m_generateCrashDump = j.value("m_generateCrashDump", modSettingsDefault::defaultGenerateCrashDump);
         m_isFirstTimeModLaunch = j.value("m_isFirstTimeModLaunch", modSettingsDefault::defaultIsFirstTimeModLaunch);
 
         m_isUseDedicatedNadeKeys = j.value("m_isUseDedicatedNadeKeys", modSettingsDefault::defaultIsUseDedicatedNadeKeys);
@@ -191,6 +192,7 @@ void modSettings::saveSettings()
 
     nlohmann::json j;
 
+    j["m_generateCrashDump"] = m_generateCrashDump;
     j["m_isFirstTimeModLaunch"] = m_isFirstTimeModLaunch;
 
     j["m_isUseDedicatedNadeKeys"] = m_isUseDedicatedNadeKeys;
@@ -428,7 +430,9 @@ void modSettings::apply()
 //    }
 //}
 
-
+bool modSettings::getGenerateCrashDump() {
+    return m_generateCrashDump;
+}
 
 bool modSettings::getIsFirstTimeModLaunch()  {
     return m_isFirstTimeModLaunch;

--- a/DE/modSettings.h
+++ b/DE/modSettings.h
@@ -46,6 +46,7 @@ private:
 	//? this will be true as long as the user has not been in the mod menu at least once, which is ok because they will need to go in the menu to enabled the custom hud anyway. The idea is that the settings save only when out of the mod menu.
 	static inline bool m_isLoadSettingsCalled = false; //! set to true first time settings loaded, even if it fails.
 	
+	static inline bool m_generateCrashDump = modSettingsDefault::defaultGenerateCrashDump;
 	static inline bool m_isFirstTimeModLaunch = modSettingsDefault::defaultIsFirstTimeModLaunch;
 
 	static inline bool m_isUseDedicatedNadeKeys = modSettingsDefault::defaultIsUseDedicatedNadeKeys;
@@ -240,6 +241,8 @@ public:
 	//static void sanatizeData(std::string callerStr);
 
 	//static void update(bool isShowModMenu); //! loading and saving when needed
+
+	static bool getGenerateCrashDump();
 
 	//? will be set to false fist time this func is called.
 	static bool getIsFirstTimeModLaunch();

--- a/DE_Qol_xinput1_3_wrapper.vcxproj
+++ b/DE_Qol_xinput1_3_wrapper.vcxproj
@@ -476,7 +476,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>msimg32.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Vanilla|x64'">
@@ -492,7 +492,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>msimg32.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Sandbox|x64'">
@@ -508,7 +508,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>msimg32.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -676,7 +676,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>msimg32.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -698,7 +698,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>msimg32.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -720,7 +720,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>msimg32.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -742,7 +742,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>msimg32.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -764,7 +764,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>msimg32.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -786,7 +786,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>msimg32.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/dllmain.h
+++ b/dllmain.h
@@ -3,6 +3,7 @@
 //? atm the order and includs in this file is important to be able to build, we need to sanatize all this....
 
 #include <windows.h>
+#include <DbgHelp.h>
 #include <thread>
 #include <intrin.h>
 #include <string>


### PR DESCRIPTION
It took me a bit longer but I have finally implemented crash dump generation in case the mod crashed via `SetUnhandledExceptionFilter`.

I have added an entry (`m_generateCrashDump`) in the settings json file to make it configurable with no crash dump generation as the default.

If the mod crashes and `m_generateCrashDump` is set to true, the file `DE_AdvancedOptionsMod.dmp` is written to the game base directory. You can open this file with WinDbg and analyze the crash so it shows you the source line on which the mod crashed.

I have tested this by just adding

```
volatile int* tmp = nullptr;
int tmp1 = *tmp;
```

after the exception filter is set to make the mod crash on purpose.
I got a readable crash dump I could analyze just fine.

I hope this is what you were looking for. Let me know if you need any changes to it.

Cheers